### PR TITLE
Add recursemode parameter to chose to apply ACL's recursivel

### DIFF
--- a/lib/puppet/provider/acl/posixacl.rb
+++ b/lib/puppet/provider/acl/posixacl.rb
@@ -65,7 +65,7 @@ Puppet::Type.type(:acl).provide(:posixacl, :parent => Puppet::Provider::Acl) do
   
   def check_recursive
     # Changed functionality to return boolean true or false
-    value = (@resource.value(:recursive) == :true)
+    value = (@resource.value(:recursive) == :true and resource.value(:recursemode) == :lazy)
   end
 
   def check_exact

--- a/lib/puppet/type/acl.rb
+++ b/lib/puppet/type/acl.rb
@@ -55,6 +55,17 @@ Puppet::Type.newtype(:acl) do
     end
   end
 
+  newparam(:recursemode) do
+    desc "Should Puppet apply the ACL recursively with the -R option or
+      apply it to individual files?
+
+      lazy means -R option
+      deep means apply to every file"
+
+    newvalues(:lazy, :deep)
+    defaultto :lazy
+  end
+
   autorequire(:file) do
     if self[:path]
       [self[:path]]
@@ -197,6 +208,30 @@ Puppet::Type.newtype(:acl) do
     desc "Apply ACLs recursively."
     newvalues(:true, :false)
     defaultto :false
+  end
+
+  def newchild(path)
+    full_path = ::File.join(self[:path], path)
+    options = @original_parameters.merge(:name => full_path).reject { |param, value| value.nil? }
+    unless File.directory?(self[:path]) then
+      option[:permission].reject! { |acl| acl.split(':', -1).length == 4 } if options.include?(:permission)
+    end
+    [:recursive, :recursemode, :path].each do |param|
+      options.delete(param) if options.include?(param)
+    end
+    self.class.new(options)
+  end
+
+  def generate
+    return [] unless self[:recursive] == :true and self[:recursemode] == :deep
+    return [] unless File.directory?(self[:path])
+    results = []
+    Dir.chdir(self[:path]) do
+      Dir['**/*'].each do |path|
+        results << newchild(path)
+      end
+    end
+    results
   end
 
   validate do

--- a/spec/unit/puppet/type/acl_spec.rb
+++ b/spec/unit/puppet/type/acl_spec.rb
@@ -92,9 +92,29 @@ describe acl_type do
       expect(resource[:name]).to eq('/tmp/foo')
       expect(resource[:recursive]).to eq(:false)
     end
+    it 'should get recursemode lazy by default' do
+      resource = acl_type.new :name => '/tmp/foo', :permission => ['o::rwx']
+      expect(resource[:name]).to eq('/tmp/foo')
+      expect(resource[:recursemode]).to eq(:lazy)
+    end
+    it 'should accept a recursemode deep' do
+      resource = acl_type.new :name => '/tmp/foo', :permission => ['o::rwx'], :recursemode => 'deep'
+      expect(resource[:name]).to eq('/tmp/foo')
+      expect(resource[:recursemode]).to eq(:deep)
+    end
+    it 'should accept a recursemode lazy' do
+      resource = acl_type.new :name => '/tmp/foo', :permission => ['o::rwx'], :recursemode => :lazy
+      expect(resource[:name]).to eq('/tmp/foo')
+      expect(resource[:recursemode]).to eq(:lazy)
+    end
     it 'should fail with a wrong action' do
       expect{
         acl_type.new :name => '/tmp/foo', :permission => ['o::rwx'], :action => :xset
+      }.to raise_error
+    end
+    it 'should fail with a wrong recurselimit' do
+      expect{
+        acl_type.new :name => '/tmp/foo', :permission => ['o::rwx'], :recurselimit => :a
       }.to raise_error
     end
     it 'should fail with a wrong first argument' do


### PR DESCRIPTION
This commit adds a Recursemode parameter to generate additional
resources for children files when recurse is set to true.

Depends on dobbymoodge/puppet-acl#11.