### PR TITLE
Adds space around operators in ternary expressions

### DIFF
--- a/lib/puppet/type/acl.rb
+++ b/lib/puppet/type/acl.rb
@@ -187,15 +187,15 @@ Puppet::Type.newtype(:acl) do
       p = a.shift
       if p =~ /[0-7]/
         p = p.oct
-        r << ( p | 4 ? 'r':'-')
-        r << ( p | 2 ? 'w':'-')
-        r << ( p | 1 ? 'x':'-')
+        r << (p | 4 ? 'r' : '-')
+        r << (p | 2 ? 'w' : '-')
+        r << (p | 1 ? 'x' : '-')
       else
         # Not the most efficient but checks for multiple and invalid chars.
         s = p.tr '-', ''
-        r << (s.sub!('r', '')?'r':'-')
-        r << (s.sub!('w', '')?'w':'-')
-        r << (s.sub!('x', '')?'x':'-')#'
+        r << (s.sub!('r', '') ? 'r' : '-')
+        r << (s.sub!('w', '') ? 'w' : '-')
+        r << (s.sub!('x', '') ? 'x' : '-')
         if !s.empty?
           raise ArgumentError, %(Invalid permission set "#{p}".)
         end


### PR DESCRIPTION
Some syntax-highlighting parsers (emacs ruby-mode, github, pry, etc.)
don't handle this construct well: `((expr)?'a':'b')` and barf up the
rest of the file highlighting as a result.