### PR TITLE
Fix ruby 1.8.7 quirks

### DIFF
--- a/lib/puppet/type/acl.rb
+++ b/lib/puppet/type/acl.rb
@@ -218,7 +218,7 @@ Puppet::Type.newtype(:acl) do
     }
     Set.new((non_default + default).map { |perm|
       key = perm.split(':')[0..1].join(':')
-      matching_default = default.reject { |perm| perm !~ /^#{key}:/ }
+      matching_default = default.reject { |tmp_perm| tmp_perm !~ /^#{key}:/ }
       if (matching_default.length > 0)
         matching_default
       else

--- a/spec/unit/puppet/type/acl_spec.rb
+++ b/spec/unit/puppet/type/acl_spec.rb
@@ -134,10 +134,10 @@ describe acl_type do
     advanced_perms = ['user:foo:rwx', 'group:foo:rwx', 'default:user:foo:---']
     advanced_perms_results = ['user:foo:---', 'group:foo:rwx']
     it 'should not do anything with no defaults' do
-      expect(acl_type.pick_default_perms(basic_perms)).to eq(basic_perms)
+      expect(acl_type.pick_default_perms(basic_perms)).to match_array(basic_perms)
     end
     it 'should override defaults' do
-      expect(acl_type.pick_default_perms(advanced_perms)).to eq(advanced_perms_results)
+      expect(acl_type.pick_default_perms(advanced_perms)).to match_array(advanced_perms_results)
     end
   end
 


### PR DESCRIPTION
`type/acl.rb` had a scoping/namespacing problem where a block parameter `|perm|` was used inside of a block with its own block parameter `|perm|`. Changed the inner param to `|tmp_perm|` fixed this for 1.8.7.

`acl_spec.rb` was comparing arrays using the [`eq`](https://www.relishapp.com/rspec/rspec-expectations/v/3-3/docs/built-in-matchers/equality-matchers) matcher - which cares about array order - instead of the [`match_array`](https://www.relishapp.com/rspec/rspec-expectations/v/3-3/docs/built-in-matchers/contain-exactly-matcher) matcher, which disregards order.