### PR TITLE
Fixes ACL's with spaces

### DIFF
--- a/lib/puppet/provider/acl/posixacl.rb
+++ b/lib/puppet/provider/acl/posixacl.rb
@@ -54,7 +54,7 @@ Puppet::Type.type(:acl).provide(:posixacl, :parent => Puppet::Provider::Acl) do
     getfacl('--absolute-names', '--no-effective', @resource.value(:path)).split("\n").each do |line|
       # Strip comments and blank lines
       if !(line =~ /^#/) and !(line == "")
-        value << line
+        value << line.gsub('\040', ' ')
       end
     end
     value.sort

--- a/spec/unit/puppet/provider/posixacl_spec.rb
+++ b/spec/unit/puppet/provider/posixacl_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rspec/mocks'
 
 provider_class = Puppet::Type.type(:acl).provider(:posixacl)
 
@@ -13,5 +14,14 @@ describe provider_class do
     expect{
       provider_class.command :setfacl
     }.not_to raise_error
+  end
+  it 'encodes spaces in group names' do
+    RSpec::Mocks.with_temporary_scope do
+      Puppet::Type.stubs(:getfacl).returns("group:test group:rwx\n")
+      File.stubs(:exist?).returns(true)
+      expect{
+        provider_class.command :permission
+      } == ['group:test\040group:rwx']
+    end
   end
 end


### PR DESCRIPTION
Fix for ACL's with spaces, which otherwise cause ACL's to be applied with every puppet agent run.