### PR TITLE
Make posixacl default for sles

### DIFF
--- a/lib/puppet/provider/posix_acl/posixacl.rb
+++ b/lib/puppet/provider/posix_acl/posixacl.rb
@@ -5,7 +5,7 @@ Puppet::Type.type(:posix_acl).provide(:posixacl, :parent => Puppet::Provider) do
   commands :getfacl => '/usr/bin/getfacl'
 
   confine :feature => :posix
-  defaultfor :operatingsystem => [:debian, :ubuntu, :redhat, :centos, :fedora]
+  defaultfor :operatingsystem => [:debian, :ubuntu, :redhat, :centos, :fedora, :sles]
 
   def exists?
     permission


### PR DESCRIPTION
Produces useless warning about multiple default providers otherwise.